### PR TITLE
Update server.md

### DIFF
--- a/doc/book/server.md
+++ b/doc/book/server.md
@@ -230,14 +230,14 @@ if ($response instanceof SoapFault) {
 ```
 
 The last response emitted may also be retrieved for post-processing using
-`getLastResponse()`:
+`getResponse()`:
 
 ```php
 $server = new Laminas\Soap\Server(/* ... */);
 
 $server->handle();
 
-$response = $server->getLastResponse();
+$response = $server->getResponse();
 
 if ($response instanceof SoapFault) {
     /* ... */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
The documentation talks about a method called getLastResponse().

Looking at the source code in
<https://github.com/laminas/laminas-soap/blob/master/src/Server.php>
the method is getResponse(); not getLastResponse();

